### PR TITLE
Switch commit/abort from root-flattening to immediate-parent merge

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -23,6 +23,7 @@ pub enum Request {
     Unmount { mountpoint: String },
     Create { name: String, parent: String },
     NotifySwitch { mountpoint: String, branch: String },
+    GetMountBranch { mountpoint: String },
     List,
     Shutdown,
 }
@@ -324,6 +325,15 @@ impl Daemon {
                         branch
                     );
                     Response::success()
+                } else {
+                    Response::error(&format!("Mount not found: {:?}", path))
+                }
+            }
+            Request::GetMountBranch { mountpoint } => {
+                let path = PathBuf::from(&mountpoint);
+                let mounts = self.mounts.lock();
+                if let Some(info) = mounts.get(&path) {
+                    Response::success_with_data(serde_json::json!(info.current_branch))
                 } else {
                     Response::error(&format!("Mount not found: {:?}", path))
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,9 @@ pub enum BranchError {
     #[error("cannot operate on main branch")]
     CannotOperateOnMain,
 
+    #[error("cannot commit/abort non-leaf branch '{0}'")]
+    NotALeaf(String),
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1230,9 +1230,9 @@ impl Filesystem for BranchFs {
             BRANCHFS_IOC_COMMIT => {
                 log::info!("ioctl: COMMIT for branch '{}'", branch_name);
                 match self.manager.commit(&branch_name) {
-                    Ok(()) => {
-                        self.switch_to_branch("main");
-                        log::info!("Switched to main branch after commit");
+                    Ok(parent) => {
+                        self.switch_to_branch(&parent);
+                        log::info!("Switched to branch '{}' after commit", parent);
                         reply.ioctl(0, &[])
                     }
                     Err(e) => {
@@ -1244,9 +1244,9 @@ impl Filesystem for BranchFs {
             BRANCHFS_IOC_ABORT => {
                 log::info!("ioctl: ABORT for branch '{}'", branch_name);
                 match self.manager.abort(&branch_name) {
-                    Ok(()) => {
-                        self.switch_to_branch("main");
-                        log::info!("Switched to main branch after abort");
+                    Ok(parent) => {
+                        self.switch_to_branch(&parent);
+                        log::info!("Switched to branch '{}' after abort", parent);
                         reply.ioctl(0, &[])
                     }
                     Err(e) => {

--- a/tests/test_commit.sh
+++ b/tests/test_commit.sh
@@ -101,21 +101,36 @@ test_commit_nested_branches() {
     assert_file_exists "$TEST_MNT/nest1_file.txt" "nest1 file visible"
     assert_file_exists "$TEST_MNT/nest2_file.txt" "nest2 file visible"
 
-    # Commit from nest2
+    # Commit from nest2 — merges into nest1, NOT to base
     do_commit
 
-    # Both files should be in base
-    assert_file_exists "$TEST_BASE/nest1_file.txt" "nest1 file in base after commit"
-    assert_file_exists "$TEST_BASE/nest2_file.txt" "nest2 file in base after commit"
-
-    # Both branches should be gone
-    assert_branch_not_exists "nest1" "nest1 removed after commit"
+    # nest2 should be gone, nest1 should still exist
     assert_branch_not_exists "nest2" "nest2 removed after commit"
+    assert_branch_exists "nest1" "nest1 still exists after nest2 commit"
+
+    # Files should NOT be in base yet
+    assert_file_not_exists "$TEST_BASE/nest1_file.txt" "nest1 file NOT in base yet"
+    assert_file_not_exists "$TEST_BASE/nest2_file.txt" "nest2 file NOT in base yet"
+
+    # But nest2_file should be visible via nest1's @branch path
+    assert_file_exists "$TEST_MNT/@nest1/nest2_file.txt" "nest2 file visible via @nest1"
+    assert_file_exists "$TEST_MNT/@nest1/nest1_file.txt" "nest1 file visible via @nest1"
+
+    # Now switch to nest1 and commit to base
+    do_switch "nest1"
+    do_commit
+
+    # Both files should now be in base
+    assert_file_exists "$TEST_BASE/nest1_file.txt" "nest1 file in base after nest1 commit"
+    assert_file_exists "$TEST_BASE/nest2_file.txt" "nest2 file in base after nest1 commit"
+
+    # nest1 should be gone
+    assert_branch_not_exists "nest1" "nest1 removed after commit to base"
 
     do_unmount
 }
 
-test_commit_invalidates_all_branches() {
+test_commit_preserves_siblings() {
     setup
     do_mount
 
@@ -125,13 +140,37 @@ test_commit_invalidates_all_branches() {
 
     echo "sibling b content" > "$TEST_MNT/sibling_b_file.txt"
 
-    # Commit sibling_b
+    # Commit sibling_b — only sibling_b is removed, sibling_a preserved
     do_commit
 
-    # sibling_a should also be invalidated (removed due to epoch change)
-    # Note: In current implementation, commit clears ALL branches except main
-    assert_branch_not_exists "sibling_a" "sibling_a invalidated after commit"
     assert_branch_not_exists "sibling_b" "sibling_b removed after commit"
+    assert_branch_exists "sibling_a" "sibling_a preserved after sibling commit"
+
+    do_unmount
+}
+
+test_commit_non_leaf_fails() {
+    setup
+    do_mount
+
+    # Create A from main, then B from A
+    do_create "branch_a" "main"
+    do_create "branch_b" "branch_a"
+
+    # Try to commit A (not a leaf, should fail)
+    if do_switch "branch_a" && "$BRANCHFS" commit "$TEST_MNT" --storage "$TEST_STORAGE" 2>/dev/null; then
+        TESTS_RUN=$((TESTS_RUN + 1))
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}✗${NC} Commit non-leaf should fail"
+    else
+        TESTS_RUN=$((TESTS_RUN + 1))
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}✓${NC} Commit non-leaf correctly failed"
+    fi
+
+    # Both branches should still exist
+    assert_branch_exists "branch_a" "branch_a still exists after failed commit"
+    assert_branch_exists "branch_b" "branch_b still exists after failed commit"
 
     do_unmount
 }
@@ -142,6 +181,7 @@ run_test "Commit Modified File" test_commit_modified_file
 run_test "Commit Deleted File" test_commit_deleted_file
 run_test "Commit Switches to Main" test_commit_switches_to_main
 run_test "Commit Nested Branches" test_commit_nested_branches
-run_test "Commit Invalidates All Branches" test_commit_invalidates_all_branches
+run_test "Commit Preserves Siblings" test_commit_preserves_siblings
+run_test "Commit Non-Leaf Fails" test_commit_non_leaf_fails
 
 print_summary

--- a/tests/test_helper.sh
+++ b/tests/test_helper.sh
@@ -121,6 +121,12 @@ do_abort() {
     "$BRANCHFS" abort "$TEST_MNT" --storage "$TEST_STORAGE"
 }
 
+# Switch to a branch by writing to the ctl file
+do_switch() {
+    local name="$1"
+    echo -n "switch:${name}" > "$TEST_MNT/.branchfs_ctl"
+}
+
 # List branches
 do_list() {
     "$BRANCHFS" list --storage "$TEST_STORAGE"


### PR DESCRIPTION
Commit and abort now operate only on leaf branches (no children). Committing a leaf merges its delta into the immediate parent's delta (or applies to base if parent is main), preserving sibling branches. Aborting discards only the single leaf branch. This enables incremental nested-branch workflows instead of flattening the entire chain.